### PR TITLE
Fix verb agreement

### DIFF
--- a/problems/for/how_many_zeroes.txt
+++ b/problems/for/how_many_zeroes.txt
@@ -5,7 +5,7 @@ Statement:
 Given N numbers: the first number in the input is N, after that N integers are given. Count the number of zeros among the given integers and print it.
 
 <p>
-You need to count the number of numbers that are equals to zero, not the number of zero digits.
+You need to count the number of numbers that are equal to zero, not the number of zero digits.
 
 
 Test:


### PR DESCRIPTION
They are all equal one time.  equals would be correct if the subject were "number" and "equal" were the verb.  But in this case, the verb is "are", so it agrees with the subject and equal is a singular state.